### PR TITLE
Add test for KMeans pipeline label extraction

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import numpy as np
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.cluster import KMeans
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from ml_playground.core.pipeline import _last_estimator_labels
+
+
+def test_last_estimator_labels_returns_expected_array():
+    X = np.array([[0, 0], [0, 1], [9, 8], [8, 9]])
+    pipe = Pipeline([
+        ("scaler", StandardScaler()),
+        ("kmeans", KMeans(n_clusters=2, random_state=0)),
+    ])
+
+    pipe.fit(X)
+
+    labels = _last_estimator_labels(pipe, X)
+    expected = np.array([1, 1, 0, 0])
+
+    assert isinstance(labels, np.ndarray)
+    assert np.array_equal(labels, expected)


### PR DESCRIPTION
## Summary
- add pytest verifying `_last_estimator_labels` returns KMeans labels without error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a70fb7b99083218832288e4c1a1156