### PR TITLE
Fix typo in README

### DIFF
--- a/README
+++ b/README
@@ -37,11 +37,11 @@ Gehe dann in das Projektverzeichnis:
 
 cd streamlit_ml
 
-Virtuele Entwicklungsumgebung erstellen:
+Virtuelle Entwicklungsumgebung erstellen:
 
 python -m venv .venv
 
-Virtuele Entwicklungsumgebung aktivieren:
+Virtuelle Entwicklungsumgebung aktivieren:
 
 .venv\Scripts\activate
 
@@ -61,11 +61,11 @@ Gehe dann in das Projektverzeichnis:
 
 cd <project_name>
 
-Virtuele Entwicklungsumgebung erstellen:
+Virtuelle Entwicklungsumgebung erstellen:
 
 python3 -m venv .venv
 
-Virtuele Entwicklungsumgebung aktivieren:
+Virtuelle Entwicklungsumgebung aktivieren:
 
 source .venv/bin/activate
 


### PR DESCRIPTION
## Summary
- correct spelling of "Virtuelle Entwicklungsumgebung" in setup instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a715025b0c83218cbbc533dbf6f4ef